### PR TITLE
Downgrade project to runs on Jdk11

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     dataBinding {

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.0.0' apply false
-    id 'com.android.library' version '8.0.0' apply false
+    id 'com.android.application' version '7.4.0' apply false
+    id 'com.android.library' version '7.4.0' apply false
     id "org.jetbrains.kotlin.android" version "1.8.10" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk11

--- a/scimitar-annotations/build.gradle
+++ b/scimitar-annotations/build.gradle
@@ -6,5 +6,5 @@ group = 'com.github.Sserra90.scimitar'
 
 apply from: "${rootDir}/tools/publish.gradle"
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11

--- a/scimitar-processor/build.gradle
+++ b/scimitar-processor/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11

--- a/scimitar-runtime/build.gradle
+++ b/scimitar-runtime/build.gradle
@@ -34,11 +34,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 


### PR DESCRIPTION
The project when targetting AGP 8.0.0 can't be used by other projects that aren't that new, so here we are downgrading it back to a more compatible version